### PR TITLE
Script Update

### DIFF
--- a/users/CrimsonAlpha_002/c2002000084.lua
+++ b/users/CrimsonAlpha_002/c2002000084.lua
@@ -2,39 +2,84 @@
 Duel.LoadScript("_load_.lua")
 local s,id=GetID()
 function s.initial_effect(c)
-	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsSetCard,SET_ZEFRA))
-	--atk
+	local e0=aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsSetCard,SET_ZEFRA))
+	e0:SetDescription(aux.Stringid(id,0))
+	e0:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
+	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_EQUIP)
-	e1:SetCode(EFFECT_UPDATE_ATTACK)
-	e1:SetValue(s.atkval)
+	e1:SetDescription(aux.Stringid(id,1))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
-	--Prevent effect target
+	--atk
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_EQUIP)
-	e2:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
-	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-	e2:SetValue(aux.tgoval)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(s.atkval)
 	c:RegisterEffect(e2)
-	--Cannot be destroyed by the opponent's card effects
+	--Prevent effect target
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
-	e3:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
-	e3:SetValue(aux.indoval)
+	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetValue(aux.tgoval)
 	c:RegisterEffect(e3)
-	--spsummon
-	local params={nil,nil,s.extrafil,s.extraop,s.forcedmat}
+	--Cannot be destroyed by the opponent's card effects
 	local e4=Effect.CreateEffect(c)
-	e4:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
-	e4:SetType(EFFECT_TYPE_IGNITION)
-	e4:SetRange(LOCATION_SZONE)
-	e4:SetCondition(s.fcond)
-	e4:SetCountLimit(1,id)
-	e4:SetTarget(Fusion.SummonEffTG(table.unpack(params)))
-	e4:SetOperation(Fusion.SummonEffOP(table.unpack(params)))
+	e4:SetType(EFFECT_TYPE_EQUIP)
+	e4:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	e4:SetValue(aux.indoval)
 	c:RegisterEffect(e4)
+	--spsummon
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(id,2))
+	e5:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
+	e5:SetType(EFFECT_TYPE_IGNITION)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetCondition(s.fcond)
+	e5:SetCountLimit(1)
+	e5:SetTarget(Fusion.SummonEffTG())
+	e5:SetOperation(Fusion.SummonEffOP())
+	c:RegisterEffect(e5)
 end
 s.listed_series={SET_ZEFRA}
+function s.spfilter(c,e,tp)
+	return c:IsSetCard(SET_ZEFRA) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and c:IsPublic()
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE|LOCATION_REMOVED) and chkc:IsControler(tp) and s.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE|LOCATION_REMOVED,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE|LOCATION_REMOVED,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function s.eqlimit(e,c)
+	return e:GetLabelObject()==c
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK)==0 then return end
+		Duel.Equip(tp,c,tc)
+		--Add Equip limit
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetValue(s.eqlimit)
+		e1:SetLabelObject(tc)
+		c:RegisterEffect(e1)
+	end
+end
 function s.atkval(e,c)
 	local tp=e:GetHandler():GetOwner()
 	local val=aux.GetPendulumScaleSum(tp) + aux.GetPendulumScaleSum(1-tp)

--- a/users/CrimsonAlpha_002/c2002000085.lua
+++ b/users/CrimsonAlpha_002/c2002000085.lua
@@ -4,64 +4,50 @@ local s,id=GetID()
 function s.initial_effect(c)	
 	--Activate
 	local e1=Ritual.AddProcGreater({handler=c,
-									filter=s.ritualfil,
-									extrafil=s.extrafil,
-									extratg=s.extratg,
-									extraop=s.extraop,
 									matfilter=aux.FilterBoolFunction(Card.IsType,TYPE_PENDULUM),
-									location=LOCATION_HAND|LOCATION_GRAVE,
+									location=LOCATION_HAND|LOCATION_GRAVE|LOCATION_DECK,
+									forcedselection=s.forcedselection,
 									requirementfunc=Card.GetScale})
-	e1:SetCountLimit(1,{id,0})
 	c:RegisterEffect(e1)
-	--Shuffle 1 "Zefra" monster to the Deck
+	--Return this card to hand
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_TOHAND)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_GRAVE)
-	e2:SetCountLimit(1,{id,1})
-	e2:SetCost(aux.bfgcost)
+	e2:SetCost(s.thcost)
 	e2:SetTarget(s.thtg)
 	e2:SetOperation(s.thop)
 	c:RegisterEffect(e2)
 end
 s.listed_series={SET_ZEFRA}
-function s.ritualfil(c)
-	return c:IsRitualMonster()
+function s.filter(c)
+	return c:IsFaceup() and c:IsSetCard(SET_ZEFRA) and c:GetScale()>0 and c:IsLocation(LOCATION_MZONE)
 end
-function s.mfilter(c)
-	return not Duel.IsPlayerAffectedByEffect(c:GetControler(),69832741) and c:IsSetCard(SET_ZEFRA) 
-		and c:IsAbleToRemove() and c:IsPublic() and c:GetScale()>0
-end
-function s.extrafil(e,tp,eg,ep,ev,re,r,rp,chk)
-	return Duel.GetMatchingGroup(s.mfilter,tp,LOCATION_PZONE|LOCATION_EXTRA,0,nil)
-end
-function s.extratg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,tp,LOCATION_PZONE|LOCATION_EXTRA)
-end
-function s.exfilter(c)
-	return c:IsLocation(LOCATION_PZONE|LOCATION_EXTRA) and c:IsPublic() 
-		and c:IsSetCard(SET_ZEFRA) and c:IsAbleToRemove() and c:GetScale()>0
-end
-function s.extraop(mat,e,tp,eg,ep,ev,re,r,rp,sc)
-	local rg=mat:Filter(s.exfilter,nil)
-	if #rg>0 then
-		mat:Sub(rg)
-		Duel.Remove(rg,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_RITUAL)
+function s.forcedselection(e,tp,sg,sc)
+	if sc:IsLocation(LOCATION_DECK) then
+		return sg:IsExists(s.filter,#sg,nil)
 	end
-	Duel.ReleaseRitualMaterial(mat)
+	return true
 end
-function s.thfilter(c)
-	return c:IsSetCard(SET_ZEFRA) and c:IsPublic() and c:IsMonster() and c:IsAbleToHand()
+function s.cfilter(c)
+	return c:IsSetCard(SET_ZEFRA) and c:IsPublic() and c:IsAbleToDeckAsCost()
 end
+function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_REMOVED|LOCATION_EXTRA,0,1,nil) end
+	local tc=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_REMOVED|LOCATION_EXTRA,0,1,1,nil):GetFirst()
+	Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_COST)
+end
+
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.thfilter,tp,LOCATION_REMOVED,0,1,nil) end
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_REMOVED)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToHand() end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,c,1,tp,LOCATION_GRAVE)
+
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.SelectMatchingCard(tp,s.thfilter,tp,LOCATION_REMOVED,0,1,1,nil)
-	if #g>0 then
-		Duel.SendtoHand(g,nil,REASON_EFFECT)
-		Duel.ConfirmCards(1-tp,g)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SendtoHand(c,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,c)
 	end
 end

--- a/users/CrimsonAlpha_002/c2002000091.lua
+++ b/users/CrimsonAlpha_002/c2002000091.lua
@@ -78,24 +78,33 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	if ct<=0 then return end
 	if Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) then ct=1 end
 	local sg=aux.SelectUnselectGroup(g,e,tp,1,ct,aux.dpcheck(Card.GetAttribute),1,tp,HINTMSG_SPSUMMON)
-	if #sg>0 then
+	if #sg>0 then 
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
-		for tc in aux.Next(sg) do
-			--synchro level
-			local e2=Effect.CreateEffect(tc)
-			e2:SetType(EFFECT_TYPE_SINGLE)
-			e2:SetRange(LOCATION_MZONE)
-			e2:SetCode(EFFECT_SYNCHRO_LEVEL)
-			e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-			e2:SetValue(s.slevel)
-			tc:RegisterEffect(e2)
-		end
+		-- for tc in aux.Next(sg) do
+			-- --synchro level
+			-- local e2=Effect.CreateEffect(tc)
+			-- e2:SetType(EFFECT_TYPE_SINGLE)
+			-- e2:SetRange(LOCATION_MZONE)
+			-- e2:SetCode(EFFECT_SYNCHRO_LEVEL)
+			-- e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+			-- e2:SetValue(s.slevel)
+			-- tc:RegisterEffect(e2)
+		-- end
 	end
+	--Cannot Special Summon from the Extra Deck, except Synchro Monsters
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,2))
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CLIENT_HINT)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(function(e,c) return c:IsLocation(LOCATION_EXTRA) and not c:IsType(TYPE_SYNCHRO) end)
+	Duel.RegisterEffect(e1,tp)
 end
-function s.slevel(e,c)
-	local lv=e:GetHandler():GetLevel()
-	return 1*65536+lv
-end
+-- function s.slevel(e,c)
+	-- local lv=e:GetHandler():GetLevel()
+	-- return 1*65536+lv
+-- end
 	--Compound filter for proper target selection
 function s.tgfilter(c,e,tp)
 	return c:IsFaceup() and c:IsSetCard(SET_YANG_ZING) and c:IsMonster() and not c:IsType(TYPE_TUNER)

--- a/users/CrimsonAlpha_002/c2002000176.lua
+++ b/users/CrimsonAlpha_002/c2002000176.lua
@@ -5,17 +5,7 @@ function s.initial_effect(c)
 	c:SetUniqueOnField(1,0,id)
 	c:EnableReviveLimit()
 	Link.AddProcedure(c,s.mfilter,1,1)
-	--spsummon cost
-	local e0=Effect.CreateEffect(c)
-	e0:SetType(EFFECT_TYPE_SINGLE)
-	e0:SetCode(EFFECT_SPSUMMON_COST)
-	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e0:SetCost(s.splimcost)
-	e0:SetOperation(s.splimop)
-	c:RegisterEffect(e0)
-	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
-	Duel.AddCustomActivityCounter(id,ACTIVITY_SUMMON,s.counterfilter)
-	Duel.AddCustomActivityCounter(id,ACTIVITY_FLIPSUMMON,s.counterfilter)
+	-- Add 1 "War Rock Mountain" from Deck or GY
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -49,37 +39,12 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 s.listed_series={SET_WAR_ROCK}
-function s.mfilter(c,lc,sumtype,tp)
-	return c:IsSetCard(SET_WAR_ROCK,lc,sumtype,tp)
-end
-function s.counterfilter(c)
-	return c:IsSetCard(SET_WAR_ROCK)
-end
-function s.splimcost(e,c,tp)
-	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0
-		and Duel.GetCustomActivityCount(id,tp,ACTIVITY_SUMMON)==0
-		and Duel.GetCustomActivityCount(id,tp,ACTIVITY_FLIPSUMMON)==0
-end
-function s.splimop(e,tp,eg,ep,ev,re,r,rp)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CLIENT_HINT)
-	e1:SetDescription(aux.Stringid(id,1))
-	e1:SetTargetRange(1,0)
-	e1:SetTarget(s.splimit)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e1,tp)
-end
-function s.splimit(e,c,tp,sumtp,sumpos)
-	return not c:IsSetCard(SET_WAR_ROCK)
-end
+s.listed_names={45943516}
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)
 end
 function s.thfilter(c)
-	return c:IsSetCard(SET_WAR_ROCK) and c:IsAbleToHand()
+	return c:IsCode(45943516) and c:IsAbleToHand()
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.thfilter,tp,LOCATION_DECK,0,1,nil) end
@@ -92,16 +57,6 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	if #g>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
-		-- Cannot activate monster effects
-		local e1=Effect.CreateEffect(c)
-		e1:SetDescription(aux.Stringid(id,2))
-		e1:SetType(EFFECT_TYPE_FIELD)
-		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CLIENT_HINT)
-		e1:SetCode(EFFECT_CANNOT_ACTIVATE)
-		e1:SetTargetRange(1,0)
-		e1:SetValue(s.aclimit)
-		e1:SetReset(RESET_PHASE|PHASE_END)
-		Duel.RegisterEffect(e1,tp)
 	end
 end
 function s.aclimit(e,re,tp)
@@ -140,8 +95,6 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsAttackPos() and tc and tc:IsRelateToEffect(e)
 		and c:CanAttack() and not c:IsImmuneToEffect(e) and not tc:IsImmuneToEffect(e) then
-		Duel.CalculateDamage(c,tc)
-		c:RegisterFlagEffect(id,RESET_PHASE+PHASE_END,0,1)
 		local atkg=Duel.GetMatchingGroup(aux.FaceupFilter(Card.IsSetCard,SET_WAR_ROCK),tp,LOCATION_MZONE,0,nil)
 		for tc in aux.Next(atkg) do
 			--Increase ATK
@@ -153,5 +106,8 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 			e2:SetValue(200)
 			tc:RegisterEffect(e2)
 		end
+		Duel.BreakEffect()
+		Duel.CalculateDamage(c,tc)
+		c:RegisterFlagEffect(id,RESET_PHASE+PHASE_END,0,1)
 	end
 end


### PR DESCRIPTION
Balance Changes on the following cards:
* Jinwu, Gold of the Yang Zing - Summoned "Yang Zings" will no longer have their Levels adjusted when used for a Synchro Summon
* Infector Pain, the True Dracoverlord - Will now only negate the effects of monsters that started in the Extra Deck

Reworked the following cards:
* War Rock Aroy - Reworked to make way for additional "War Rock" cards. Now only adds "War Rock Mountain" and ATK increase happens before force attack happens.
* PSY-Framegear Iota - Will now also place Continuous Spells/Traps face-up
* Resolve of Zefra - It now has a "Pre-mature Burial" kind of effect wherein it will Special Summon a "Zefra" from GY or banishment and equip itself to the Summoned Monster. Also the effect that Fusion Summons no longer requires the equip monster.
* Zefra Divine Mirror - Loses the ability to use the Pendulum Zone and Extra Deck as resource for Ritual Fodder, but in return loses the HOPT on both of it's effects to better focus on Ritual-centric builds, as well as allow Ritual Summoning from the Deck by using only face-up "Zefra" monsters on the field as Tributes. Finally, this card recycles itself by shuffling banished and face-up Extra Deck "Zefra" cards back to the Deck.

Bug Fix:
* World Legacy Beginnings - Was not resolving properly when trying to Special Summon a "World Chalice" Normal Pendulum Monster from the Extra Deck.